### PR TITLE
Add a ThreadAPI_Sleep in EventHubClient.c

### DIFF
--- a/eventhub_client/src/eventhubclient.c
+++ b/eventhub_client/src/eventhubclient.c
@@ -58,6 +58,8 @@ static int EventhubClientThread(void* userContextCallback)
         {
             LOG_ERROR(EVENTHUBCLIENT_ERROR);
         }
+
+        ThreadAPI_Sleep(1);
     }
     return 0;
 }

--- a/eventhub_client/tests/eventhubclient_unittests/eventhubclient_unittests.cpp
+++ b/eventhub_client/tests/eventhubclient_unittests/eventhubclient_unittests.cpp
@@ -368,6 +368,9 @@ public:
         }
     MOCK_METHOD_END(COND_RESULT, COND_OK);
 
+    MOCK_STATIC_METHOD_1(, void, ThreadAPI_Sleep, unsigned int, milliseconds)
+    MOCK_VOID_METHOD_END()
+
     MOCK_STATIC_METHOD_1(, void, Condition_Deinit, COND_HANDLE, handle)
         free(handle);
     MOCK_VOID_METHOD_END()
@@ -409,6 +412,8 @@ DECLARE_GLOBAL_MOCK_METHOD_1(CEventHubClientMocks, , void, EventData_Destroy, EV
 DECLARE_GLOBAL_MOCK_METHOD_1(CEventHubClientMocks, , const char*, EventData_GetPartitionKey, EVENTDATA_HANDLE, eventDataHandle);
 DECLARE_GLOBAL_MOCK_METHOD_5(CEventHubClientMocks, , EVENTDATA_RESULT, EventData_GetPropertyByIndex, EVENTDATA_HANDLE, eventDataHandle, size_t, propertyIndex, const char**, propertyName, const unsigned char**, propertyValue, size_t*, propertySize);
 DECLARE_GLOBAL_MOCK_METHOD_1(CEventHubClientMocks, , size_t, EventData_GetPropertyCount, EVENTDATA_HANDLE, eventDataHandle);
+
+DECLARE_GLOBAL_MOCK_METHOD_1(CEventHubClientMocks, , void, ThreadAPI_Sleep, unsigned int, milliseconds);
 
 //DECLARE_GLOBAL_MOCK_METHOD_0(CEventHubClientMocks, , const char*, EventHubClient_GetVersionString);
 


### PR DESCRIPTION
Add a ThreadAPI_Sleep in EventHubClient.c in order to fix the high CPU load reported in Issue #6 .