### PR TITLE
cmake: add install-rule for eventhub_client lib and headers

### DIFF
--- a/eventhub_client/CMakeLists.txt
+++ b/eventhub_client/CMakeLists.txt
@@ -51,6 +51,13 @@ add_library(eventhub_client
 target_link_libraries(eventhub_client uamqp)
 linkSharedUtil(eventhub_client)
 
+install(TARGETS eventhub_client
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(FILES ${eventhub_client_h_files}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azure_event_hubs)
+
 add_subdirectory(samples)
 
 if (${run_unittests})


### PR DESCRIPTION
I'm using the eventhub_client-library on a platform where I need to install it. We could copy it in parent cmake-files, but using the install()-function is more appropriate as it is already used in other places.