### PR TITLE
fix memory leak when adding partition annotation to message, fix usage of uninitialized structure

### DIFF
--- a/eventhub_client/src/eventhubclient_ll.c
+++ b/eventhub_client/src/eventhubclient_ll.c
@@ -184,6 +184,7 @@ static int add_partition_key_to_message(MESSAGE_HANDLE message, EVENTDATA_HANDLE
             amqpvalue_destroy(partition_value);
             amqpvalue_destroy(partition_name);
             amqpvalue_destroy(partition_map);
+            amqpvalue_destroy(partition_annotation);
         }
     }
     else

--- a/eventhub_client/src/eventhubclient_ll.c
+++ b/eventhub_client/src/eventhubclient_ll.c
@@ -512,6 +512,7 @@ static int initialize_uamqp_stack_common(EVENTHUBCLIENT_LL_HANDLE eventhub_clien
         const IO_INTERFACE_DESCRIPTION* saslclientio_interface;
         TLSIO_CONFIG tls_io_config;
 
+        memset(&tls_io_config, 0, sizeof(tls_io_config));
         tls_io_config.hostname = host_name_temp;
         tls_io_config.port = 5671;
 


### PR DESCRIPTION
This 2 modifications fix 2 problems i have encountered by trying the send async example of the eventhub client and some variations of it by running with valgrind or by using the address sanitizer functionalty of gcc.
