### PR TITLE
Fix a bug - replace platform_init with platform_deinit

### DIFF
--- a/eventhub_client/samples/send_batch/send_batch.c
+++ b/eventhub_client/samples/send_batch/send_batch.c
@@ -105,7 +105,7 @@ int SendBatch_Sample(void)
             EventData_Destroy(eventDataList[i]);
         }
 
-        platform_init();
+        platform_deinit();
     }
 
     return result;


### PR DESCRIPTION
I found out there is a bug in send_batch sample:
At the end of SendBatch_Sample function, instead of platform_deinit, platform_init has been called which is incorrect.
This PR will fix this bug.